### PR TITLE
Fix `setViewControllers:direction:animated:completion:` crash 

### DIFF
--- a/GUITabPagerViewController/Classes/GUITabPagerViewController.m
+++ b/GUITabPagerViewController/Classes/GUITabPagerViewController.m
@@ -97,10 +97,18 @@
       [[self delegate] tabPager:self willTransitionToTabAtIndex:index];
     }
     
+    UIPageViewControllerNavigationDirection direction = (index > [self selectedIndex]) ? UIPageViewControllerNavigationDirectionForward : UIPageViewControllerNavigationDirectionReverse;
+
     [[self pageViewController]  setViewControllers:@[[self viewControllers][index]]
-                                         direction:(index > [self selectedIndex]) ? UIPageViewControllerNavigationDirectionForward : UIPageViewControllerNavigationDirectionReverse
+                                         direction:direction
                                           animated:YES
                                         completion:^(BOOL finished) {
+                                          if (finished) {
+                                            dispatch_async(dispatch_get_main_queue(), ^{
+                                              // bug fix for UIPageViewController
+                                                [self.pageViewController setViewControllers:@[[self viewControllers][index]] direction:direction animated:NO completion:NULL];
+                                            });
+                                          }
                                           [self setSelectedIndex:index];
                                           
                                           if ([[self delegate] respondsToSelector:@selector(tabPager:didTransitionToTabAtIndex:)]) {

--- a/GUITabPagerViewController/Classes/GUITabPagerViewController.m
+++ b/GUITabPagerViewController/Classes/GUITabPagerViewController.m
@@ -106,7 +106,7 @@
                                           if (finished) {
                                             dispatch_async(dispatch_get_main_queue(), ^{
                                               // bug fix for UIPageViewController
-                                                [self.pageViewController setViewControllers:@[[self viewControllers][index]] direction:direction animated:NO completion:NULL];
+                                                [self.pageViewController setViewControllers:@[[self viewControllers][index]] direction:direction animated:NO completion:nil];
                                             });
                                           }
                                           [self setSelectedIndex:index];


### PR DESCRIPTION
Fix `setViewControllers:direction:animated:completion:` crash on UIPageViewController with transition style `UIPageViewControllerTransitionStyleScroll` and animated flag `YES`

http://stackoverflow.com/a/17330606
